### PR TITLE
Fix editing out-of-bounds

### DIFF
--- a/src/app/excel-like/excel-like.component.ts
+++ b/src/app/excel-like/excel-like.component.ts
@@ -98,6 +98,11 @@ export class ExcelLikeComponent implements AfterViewInit {
   }
 
   startEdit(i: number, j: number): void {
+    const maxRow = this.items[0]?.subDivs.length ?? 0;
+    if (i < 0 || j < 0 || i >= this.items.length || j >= maxRow) {
+      return;
+    }
+
     this.editingCell = { i, j };
     setTimeout(() => {
       const inputEl = document.querySelector(


### PR DESCRIPTION
## Summary
- validate row/column indices before entering edit mode

## Testing
- `npm test` *(fails: ng not found)*